### PR TITLE
Remove HTMLProofer as a local dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,6 @@ end
 
 group :test do
   gem 'codecov', require: false
-  gem 'html-proofer', require: false
   gem 'rake', require: false
   gem 'rspec', require: false
   gem 'rspec-html-matchers', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,22 +14,11 @@ GEM
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
-    ethon (0.16.0)
-      ffi (>= 1.15.0)
     eventmachine (1.2.7)
     ffi (1.15.5)
     forwardable-extended (2.6.0)
     google-protobuf (3.21.12-x86_64-darwin)
     google-protobuf (3.21.12-x86_64-linux)
-    html-proofer (4.4.3)
-      addressable (~> 2.3)
-      mercenary (~> 0.3)
-      nokogiri (~> 1.13)
-      parallel (~> 1.10)
-      rainbow (~> 3.0)
-      typhoeus (~> 1.3)
-      yell (~> 2.0)
-      zeitwerk (~> 2.5)
     http_parser.rb (0.8.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -132,12 +121,8 @@ GEM
     simplecov_json_formatter (0.1.4)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    typhoeus (1.4.0)
-      ethon (>= 0.9.0)
     unicode-display_width (2.3.0)
     webrick (1.7.0)
-    yell (2.2.2)
-    zeitwerk (2.6.6)
 
 PLATFORMS
   x86_64-darwin-20
@@ -146,7 +131,6 @@ PLATFORMS
 DEPENDENCIES
   bytesize
   codecov
-  html-proofer
   jekyll
   jekyll-sitemap
   nokogiri

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,6 @@ require 'rake'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 require 'jekyll'
-require 'html-proofer'
 
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.pattern = Dir.glob('spec/*_spec.rb')


### PR DESCRIPTION
We are using the GitHub Aciton `chabad360/htmlproofer`, so we don't need to have HTMLProofer as a Ruby Gem dependency.