### PR TITLE
Ignore sites

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -37,7 +37,7 @@ task :htmlproofer do
 
   options = {
     ignore_status_codes: [429, 302],
-    ignore_urls: [/twitter.com/, /demozoo.org/],
+    ignore_urls: [/twitter.com/, /demozoo.org/, /bitbearmusic.bandcamp.com/],
     hydra: { max_concurrency: 1 },
     cache: { timeframe: { external: '1w' } },
   }

--- a/Rakefile
+++ b/Rakefile
@@ -37,7 +37,7 @@ task :htmlproofer do
 
   options = {
     ignore_status_codes: [429, 302],
-    ignore_urls: [/twitter.com/, /demozoo.org/, /bitbearmusic.bandcamp.com/],
+    ignore_urls: [/twitter.com/, /demozoo.org/, /bitbearmusic.bandcamp.com/, /soundcloud.com/],
     hydra: { max_concurrency: 1 },
     cache: { timeframe: { external: '1w' } },
   }


### PR DESCRIPTION
Configure HTMLProofer to ignore SoundCloud and Bandcamp URLs.