### PR TITLE
Add concurrency configuration for GitHub Actions

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -6,6 +6,10 @@ env:
   RUBY_VERSION: 4.0.5
   RUBYGEMS_VERSION: 4.0.11
 
+concurrency:
+  group: jekyll-build
+  queue: max
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,9 @@ jobs:
   htmlproofer:
     runs-on: ubuntu-latest
     needs: build
+    concurrency:
+      group: htmlproofer
+      queue: max
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Add concurrency configuration for GitHub Actions to avoid concurrent runs of Jekyll build and HTMLProofer.