### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: test
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 env:
   RUBY_VERSION: 4.0.5
   RUBYGEMS_VERSION: 4.0.11


### PR DESCRIPTION
Potential fix for [https://github.com/asbjornu/bitbear.music/security/code-scanning/4](https://github.com/asbjornu/bitbear.music/security/code-scanning/4)

Add an explicit top-level `permissions` block in `.github/workflows/test.yml` so all jobs in this workflow get least-privilege token access by default.

Best single fix without changing functionality:
- Insert under `on:` (before `env:` is fine) a root-level block:
  - `permissions:`
  - `contents: read`

Why this is best:
- It addresses all jobs at once (`build`, `htmlproofer`, `test`) unless overridden.
- It matches CodeQL’s recommended minimal starting point.
- Current steps do not require write access to repository contents, so behavior should remain unchanged.

No imports, methods, or dependencies are needed (YAML workflow-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
