### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -2,6 +2,9 @@ name: build
 
 on: [workflow_call]
 
+permissions:
+  contents: read
+
 env:
   RUBY_VERSION: 4.0.5
   RUBYGEMS_VERSION: 4.0.11


### PR DESCRIPTION
Potential fix for [https://github.com/asbjornu/bitbear.music/security/code-scanning/3](https://github.com/asbjornu/bitbear.music/security/code-scanning/3)

Add an explicit `permissions` block to `.github/workflows/_build.yml` at the workflow root (best here since there is one job and this is a reusable workflow).  
Use the minimal required scope: `contents: read`.

This preserves current functionality while enforcing least privilege for `GITHUB_TOKEN`. No imports, methods, or external definitions are needed—just YAML configuration update near the top-level keys (after `on` is a clear location).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
