### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: test
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 env:
   RUBY_VERSION: 4.0.5
   RUBYGEMS_VERSION: 4.0.11


### PR DESCRIPTION
Potential fix for [https://github.com/asbjornu/bitbear.music/security/code-scanning/2](https://github.com/asbjornu/bitbear.music/security/code-scanning/2)

Add an explicit top-level `permissions` block in `.github/workflows/test.yml` so all jobs in this workflow inherit minimal token access by default.

Best single fix (without changing behavior): add

```yml
permissions:
  contents: read
```

directly under the `on:` section (before `env:` is typical). This satisfies CodeQL’s recommendation and applies least-privilege defaults to `build`, `htmlproofer`, and `test` unless overridden elsewhere. No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
