### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,10 @@ name: test
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+  packages: read
+
 env:
   RUBY_VERSION: 4.0.5
   RUBYGEMS_VERSION: 4.0.11


### PR DESCRIPTION
Potential fix for [https://github.com/asbjornu/bitbear.music/security/code-scanning/1](https://github.com/asbjornu/bitbear.music/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/test.yml` so all jobs (including the reusable-workflow job) run with least privilege by default. The best non-breaking fix here is to set:

- `contents: read` (needed for checkout/read repo content)
- `packages: read` (safe/common minimal read scope)

Place this block near the top of the workflow (after `on:` is a standard location). This addresses the CodeQL finding without changing workflow behavior materially.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
